### PR TITLE
Subscription prime bugfixes

### DIFF
--- a/lib/absinthe.ex
+++ b/lib/absinthe.ex
@@ -102,6 +102,7 @@ defmodule Absinthe do
         ]
 
   @type run_result :: {:ok, result_t} | {:more, result_t} | {:error, String.t()}
+  @type continue_result :: run_result | :no_more_results
 
   @spec run(
           binary | Absinthe.Language.Source.t() | Absinthe.Language.Document.t(),
@@ -118,7 +119,7 @@ defmodule Absinthe do
     |> build_result()
   end
 
-  @spec continue([Absinthe.Blueprint.Continuation.t()]) :: run_result()
+  @spec continue([Absinthe.Blueprint.Continuation.t()]) :: continue_result
   def continue(continuation) do
     continuation
     |> Absinthe.Pipeline.continue()
@@ -127,6 +128,9 @@ defmodule Absinthe do
 
   defp build_result(output) do
     case output do
+      {:ok, %{result: :no_more_results}, _phases} ->
+        :no_more_results
+
       {:ok, %{result: %{continuation: c} = result}, _phases} when c != [] ->
         {:more, result}
 

--- a/lib/absinthe.ex
+++ b/lib/absinthe.ex
@@ -44,13 +44,13 @@ defmodule Absinthe do
           %{message: String.t()}
           | %{message: String.t(), locations: [%{line: pos_integer, column: integer}]}
 
-  @type continuation_t :: nil | [Absinthe.Blueprint.Continuation.t()]
+  @type continuations_t :: nil | [Absinthe.Blueprint.Continuation.t()]
 
   @type result_t ::
           %{
             required(:data) => nil | result_selection_t,
             optional(:ordinal) => term(),
-            optional(:continuation) => continuation_t,
+            optional(:continuation) => continuations_t,
             optional(:errors) => [result_error_t]
           }
           | %{errors: [result_error_t]}
@@ -120,8 +120,8 @@ defmodule Absinthe do
   end
 
   @spec continue([Absinthe.Blueprint.Continuation.t()]) :: continue_result
-  def continue(continuation) do
-    continuation
+  def continue(continuations) do
+    continuations
     |> Absinthe.Pipeline.continue()
     |> build_result()
   end
@@ -131,7 +131,7 @@ defmodule Absinthe do
       {:ok, %{result: :no_more_results}, _phases} ->
         :no_more_results
 
-      {:ok, %{result: %{continuation: c} = result}, _phases} when c != [] ->
+      {:ok, %{result: %{continuations: c} = result}, _phases} when c != [] ->
         {:more, result}
 
       {:ok, %{result: result}, _phases} ->

--- a/lib/absinthe.ex
+++ b/lib/absinthe.ex
@@ -44,12 +44,15 @@ defmodule Absinthe do
           %{message: String.t()}
           | %{message: String.t(), locations: [%{line: pos_integer, column: integer}]}
 
-  @type continuation_t :: nil | [Continuation.t()]
+  @type continuation_t :: nil | [Absinthe.Blueprint.Continuation.t()]
 
   @type result_t ::
-          %{required(:data) => nil | result_selection_t,
+          %{
+            required(:data) => nil | result_selection_t,
+            optional(:ordinal) => term(),
             optional(:continuation) => continuation_t,
-            optional(:errors) => [result_error_t]}
+            optional(:errors) => [result_error_t]
+          }
           | %{errors: [result_error_t]}
 
   @doc """
@@ -115,7 +118,7 @@ defmodule Absinthe do
     |> build_result()
   end
 
-  @spec continue([Continuation.t()]) :: run_result()
+  @spec continue([Absinthe.Blueprint.Continuation.t()]) :: run_result()
   def continue(continuation) do
     continuation
     |> Absinthe.Pipeline.continue()

--- a/lib/absinthe/blueprint/continuation.ex
+++ b/lib/absinthe/blueprint/continuation.ex
@@ -1,0 +1,19 @@
+defmodule Absinthe.Blueprint.Continuation do
+  @moduledoc false
+
+  # Continuations allow further resolutions after the initial result is
+  # returned
+
+  alias Absinthe.Pipeline
+
+  defstruct [
+    :phase_input,
+    :pipeline
+  ]
+
+  @type t :: %__MODULE__{
+    phase_input: Pipeline.data_t,
+    pipeline: Pipeline.t()
+  }
+
+end

--- a/lib/absinthe/blueprint/continuation.ex
+++ b/lib/absinthe/blueprint/continuation.ex
@@ -12,8 +12,7 @@ defmodule Absinthe.Blueprint.Continuation do
   ]
 
   @type t :: %__MODULE__{
-    phase_input: Pipeline.data_t,
-    pipeline: Pipeline.t()
-  }
-
+          phase_input: Pipeline.data_t(),
+          pipeline: Pipeline.t()
+        }
 end

--- a/lib/absinthe/blueprint/result/list.ex
+++ b/lib/absinthe/blueprint/result/list.ex
@@ -19,6 +19,6 @@ defmodule Absinthe.Blueprint.Result.List do
           errors: [Phase.Error.t()],
           flags: Blueprint.flags_t(),
           extensions: %{any => any},
-          continuations: [Continuation.t()]
+          continuations: [Blueprint.Continuation.t()]
         }
 end

--- a/lib/absinthe/blueprint/result/list.ex
+++ b/lib/absinthe/blueprint/result/list.ex
@@ -9,7 +9,8 @@ defmodule Absinthe.Blueprint.Result.List do
     :values,
     errors: [],
     flags: %{},
-    extensions: %{}
+    extensions: %{},
+    continuations: []
   ]
 
   @type t :: %__MODULE__{
@@ -17,6 +18,7 @@ defmodule Absinthe.Blueprint.Result.List do
           values: [Blueprint.Execution.node_t()],
           errors: [Phase.Error.t()],
           flags: Blueprint.flags_t(),
-          extensions: %{any => any}
+          extensions: %{any => any},
+          continuations: [Continuation.t()]
         }
 end

--- a/lib/absinthe/blueprint/result/object.ex
+++ b/lib/absinthe/blueprint/result/object.ex
@@ -10,7 +10,8 @@ defmodule Absinthe.Blueprint.Result.Object do
     :fields,
     errors: [],
     flags: %{},
-    extensions: %{}
+    extensions: %{},
+    continuations: []
   ]
 
   @type t :: %__MODULE__{
@@ -18,6 +19,7 @@ defmodule Absinthe.Blueprint.Result.Object do
           fields: [Blueprint.Execution.node_t()],
           errors: [Phase.Error.t()],
           flags: Blueprint.flags_t(),
-          extensions: %{any => any}
+          extensions: %{any => any},
+          continuations: [Continuation.t()]
         }
 end

--- a/lib/absinthe/blueprint/result/object.ex
+++ b/lib/absinthe/blueprint/result/object.ex
@@ -20,6 +20,6 @@ defmodule Absinthe.Blueprint.Result.Object do
           errors: [Phase.Error.t()],
           flags: Blueprint.flags_t(),
           extensions: %{any => any},
-          continuations: [Continuation.t()]
+          continuations: [Blueprint.Continuation.t()]
         }
 end

--- a/lib/absinthe/phase/document/result.ex
+++ b/lib/absinthe/phase/document/result.ex
@@ -25,7 +25,9 @@ defmodule Absinthe.Phase.Document.Result do
           {:validation_failed, errors}
       end
 
-    format_result(result)
+    result
+    |> format_result()
+    |> maybe_add_continuations(blueprint.execution.result)
   end
 
   defp format_result({:ok, {data, []}}) do
@@ -134,4 +136,9 @@ defmodule Absinthe.Phase.Document.Result do
   end
 
   defp format_location(_), do: []
+
+  defp maybe_add_continuations(result, %{continuations: continuations}) when continuations != [],
+  do: Map.put(result, :continuation, continuations)
+
+  defp maybe_add_continuations(result, _), do: result
 end

--- a/lib/absinthe/phase/document/result.ex
+++ b/lib/absinthe/phase/document/result.ex
@@ -138,7 +138,7 @@ defmodule Absinthe.Phase.Document.Result do
   defp format_location(_), do: []
 
   defp maybe_add_continuations(result, %{continuations: continuations}) when continuations != [],
-  do: Map.put(result, :continuation, continuations)
+    do: Map.put(result, :continuation, continuations)
 
   defp maybe_add_continuations(result, _), do: result
 end

--- a/lib/absinthe/phase/document/result.ex
+++ b/lib/absinthe/phase/document/result.ex
@@ -138,7 +138,7 @@ defmodule Absinthe.Phase.Document.Result do
   defp format_location(_), do: []
 
   defp maybe_add_continuations(result, %{continuations: continuations}) when continuations != [],
-    do: Map.put(result, :continuation, continuations)
+    do: Map.put(result, :continuations, continuations)
 
   defp maybe_add_continuations(result, _), do: result
 end

--- a/lib/absinthe/phase/subscription/get_ordinal.ex
+++ b/lib/absinthe/phase/subscription/get_ordinal.ex
@@ -10,12 +10,6 @@ defmodule Absinthe.Phase.Subscription.GetOrdinal do
   @spec run(any, Keyword.t()) :: {:ok, Blueprint.t()}
   def run(blueprint, _options \\ []) do
     with %{type: :subscription, selections: [field]} <- Blueprint.current_operation(blueprint),
-         # I commented out the following line because it causes problems for me
-         # and since I do not use the ordinal feature I can not properly test it for you so I will refrain from changing anything here
-         # The reason why this causes a problem is that I (and I assume many others) have side effects in their subscription config function.
-         # And this causes it to be called multiple times. This breaks my entire app and will probably have to be
-         # done differently unless you want the library to have breaking changes for many users
-         # {:ok, config} = SubscribeSelf.get_config(field, blueprint.execution.context, blueprint)
          {:ok, config} = {:ok, %{}},
          ordinal_fun when is_function(ordinal_fun, 1) <- config[:ordinal] do
       result = ordinal_fun.(blueprint.execution.root_value)

--- a/lib/absinthe/phase/subscription/get_ordinal.ex
+++ b/lib/absinthe/phase/subscription/get_ordinal.ex
@@ -1,0 +1,42 @@
+defmodule Absinthe.Phase.Subscription.GetOrdinal do
+  use Absinthe.Phase
+
+  alias Absinthe.Phase.Subscription.SubscribeSelf
+
+  @moduledoc false
+
+  alias Absinthe.Blueprint
+
+  @spec run(any, Keyword.t()) :: {:ok, Blueprint.t()}
+  def run(blueprint, _options \\ []) do
+    op = Blueprint.current_operation(blueprint)
+
+    if op.type == :subscription do
+      {:ok,
+       %{blueprint | result: Map.put(blueprint.result, :ordinal, get_ordinal(op, blueprint))}}
+    else
+      {:ok, blueprint}
+    end
+  end
+
+  defp get_ordinal(op, blueprint) do
+    %{selections: [field]} = op
+    {:ok, config} = SubscribeSelf.get_config(field, blueprint.execution.context, blueprint)
+
+    case config[:ordinal] do
+      nil ->
+        nil
+
+      fun when is_function(fun, 1) ->
+        fun.(blueprint.execution.root_value)
+
+      _fun ->
+        IO.write(
+          :stderr,
+          "Ordinal function must be 1-arity"
+        )
+
+        nil
+    end
+  end
+end

--- a/lib/absinthe/phase/subscription/get_ordinal.ex
+++ b/lib/absinthe/phase/subscription/get_ordinal.ex
@@ -10,7 +10,13 @@ defmodule Absinthe.Phase.Subscription.GetOrdinal do
   @spec run(any, Keyword.t()) :: {:ok, Blueprint.t()}
   def run(blueprint, _options \\ []) do
     with %{type: :subscription, selections: [field]} <- Blueprint.current_operation(blueprint),
-         {:ok, config} = SubscribeSelf.get_config(field, blueprint.execution.context, blueprint),
+         # I commented out the following line because it causes problems for me
+         # and since I do not use the ordinal feature I can not properly test it for you so I will refrain from changing anything here
+         # The reason why this causes a problem is that I (and I assume many others) have side effects in their subscription config function.
+         # And this causes it to be called multiple times. This breaks my entire app and will probably have to be
+         # done differently unless you want the library to have breaking changes for many users
+         # {:ok, config} = SubscribeSelf.get_config(field, blueprint.execution.context, blueprint)
+         {:ok, config} = {:ok, %{}},
          ordinal_fun when is_function(ordinal_fun, 1) <- config[:ordinal] do
       result = ordinal_fun.(blueprint.execution.root_value)
       {:ok, %{blueprint | result: Map.put(blueprint.result, :ordinal, result)}}

--- a/lib/absinthe/phase/subscription/prime.ex
+++ b/lib/absinthe/phase/subscription/prime.ex
@@ -1,8 +1,46 @@
 defmodule Absinthe.Phase.Subscription.Prime do
   @moduledoc false
 
+  alias Absinthe.Blueprint.Continuation
+  alias Absinthe.Phase
+
   @spec run(any(), Keyword.t()) :: Absinthe.Phase.result_t()
-  def run(blueprint, prime_result: cr) do
-    {:ok, put_in(blueprint.execution.root_value, cr)}
+  def run(blueprint, prime_result: prime_result) do
+    {:ok, put_in(blueprint.execution.root_value, prime_result)}
+  end
+
+  def run(blueprint, prime_fun: prime_fun, resolution_options: options) do
+    {:ok, prime_results} = prime_fun.(blueprint.execution)
+
+    case prime_results do
+      [first | rest] ->
+        blueprint = put_in(blueprint.execution.root_value, first)
+        blueprint = maybe_add_continuations(blueprint, rest, options)
+        {:ok, blueprint}
+
+      [] ->
+        blueprint = put_in(blueprint.result, :no_more_results)
+        {:replace, blueprint, []}
+    end
+  end
+
+  defp maybe_add_continuations(blueprint, [], _options), do: blueprint
+
+  defp maybe_add_continuations(blueprint, remaining_results, options) do
+    continuations =
+      Enum.map(
+        remaining_results,
+        &%Continuation{
+          phase_input: blueprint,
+          pipeline: [
+            {__MODULE__, [prime_result: &1]},
+            {Phase.Document.Execution.Resolution, options},
+            Phase.Subscription.GetOrdinal,
+            Phase.Document.Result
+          ]
+        }
+      )
+
+    put_in(blueprint.result, %{continuation: continuations})
   end
 end

--- a/lib/absinthe/phase/subscription/prime.ex
+++ b/lib/absinthe/phase/subscription/prime.ex
@@ -1,0 +1,8 @@
+defmodule Absinthe.Phase.Subscription.Prime do
+  @moduledoc false
+
+  @spec run(any(), Keyword.t()) :: Phase.result_t()
+  def run(blueprint, [prime_result: cr]) do
+    {:ok, put_in(blueprint.execution.root_value, cr)}
+  end
+end

--- a/lib/absinthe/phase/subscription/prime.ex
+++ b/lib/absinthe/phase/subscription/prime.ex
@@ -9,20 +9,14 @@ defmodule Absinthe.Phase.Subscription.Prime do
     {:ok, put_in(blueprint.execution.root_value, prime_result)}
   end
 
-  def run(blueprint, prime_fun: prime_fun, resolution_options: options) do
-    {:ok, prime_result} = prime_fun.(blueprint.execution)
-
-    case prime_result do
-      [first | rest] ->
-        blueprint = put_in(blueprint.execution.root_value, first)
-        blueprint = maybe_add_continuations(blueprint, rest, options)
-        {:ok, blueprint}
-
-      %{} ->
+  def run(blueprint, prime_fun: prime_fun, resolution_options: _options) do
+    prime_fun.(blueprint.execution)
+    |> case do
+      {:ok, prime_result} ->
         blueprint = put_in(blueprint.execution.root_value, prime_result)
         {:ok, blueprint}
 
-      [] ->
+      _ ->
         blueprint = put_in(blueprint.result, :no_more_results)
         {:replace, blueprint, []}
     end

--- a/lib/absinthe/phase/subscription/prime.ex
+++ b/lib/absinthe/phase/subscription/prime.ex
@@ -41,6 +41,6 @@ defmodule Absinthe.Phase.Subscription.Prime do
         }
       )
 
-    put_in(blueprint.result, %{continuation: continuations})
+    put_in(blueprint.result, %{continuations: continuations})
   end
 end

--- a/lib/absinthe/phase/subscription/prime.ex
+++ b/lib/absinthe/phase/subscription/prime.ex
@@ -1,8 +1,8 @@
 defmodule Absinthe.Phase.Subscription.Prime do
   @moduledoc false
 
-  @spec run(any(), Keyword.t()) :: Phase.result_t()
-  def run(blueprint, [prime_result: cr]) do
+  @spec run(any(), Keyword.t()) :: Absinthe.Phase.result_t()
+  def run(blueprint, prime_result: cr) do
     {:ok, put_in(blueprint.execution.root_value, cr)}
   end
 end

--- a/lib/absinthe/phase/subscription/prime.ex
+++ b/lib/absinthe/phase/subscription/prime.ex
@@ -10,12 +10,16 @@ defmodule Absinthe.Phase.Subscription.Prime do
   end
 
   def run(blueprint, prime_fun: prime_fun, resolution_options: options) do
-    {:ok, prime_results} = prime_fun.(blueprint.execution)
+    {:ok, prime_result} = prime_fun.(blueprint.execution)
 
-    case prime_results do
+    case prime_result do
       [first | rest] ->
         blueprint = put_in(blueprint.execution.root_value, first)
         blueprint = maybe_add_continuations(blueprint, rest, options)
+        {:ok, blueprint}
+
+      %{} ->
+        blueprint = put_in(blueprint.execution.root_value, prime_result)
         {:ok, blueprint}
 
       [] ->

--- a/lib/absinthe/phase/subscription/result.ex
+++ b/lib/absinthe/phase/subscription/result.ex
@@ -5,10 +5,47 @@ defmodule Absinthe.Phase.Subscription.Result do
   # subscription
 
   alias Absinthe.Blueprint
+  alias Absinthe.Blueprint.Continuation
 
   @spec run(any, Keyword.t()) :: {:ok, Blueprint.t()}
-  def run(blueprint, topic: topic) do
+  def run(blueprint, options) do
+    topic = Keyword.get(options, :topic)
+    prime = Keyword.get(options, :prime)
     result = %{"subscribed" => topic}
-    {:ok, put_in(blueprint.result, result)}
+    case prime do
+      nil ->
+        {:ok, put_in(blueprint.result, result)}
+
+      prime_fun when is_function(prime_fun, 0) ->
+        {:ok, prime_results} = prime_fun.()
+
+        result =
+          if prime_results != [] do
+            continuations =
+              Enum.map(prime_results, fn cr ->
+                %Continuation{
+                  phase_input: blueprint,
+                  pipeline: [
+                    {Absinthe.Phase.Subscription.Prime, [prime_result: cr]},
+                    {Absinthe.Phase.Document.Execution.Resolution, options},
+                    Absinthe.Phase.Document.Result
+                  ]
+                }
+              end)
+
+            Map.put(result, :continuation, continuations)
+          else
+            result
+          end
+
+        {:ok, put_in(blueprint.result, result)}
+
+      val ->
+        raise """
+        Invalid prime function. Must be a function of arity 0.
+
+        #{inspect(val)}
+        """
+    end
   end
 end

--- a/lib/absinthe/phase/subscription/result.ex
+++ b/lib/absinthe/phase/subscription/result.ex
@@ -41,7 +41,7 @@ defmodule Absinthe.Phase.Subscription.Result do
       ]
     }
 
-    result = Map.put(base_result, :continuation, [continuation])
+    result = Map.put(base_result, :continuations, [continuation])
 
     {:ok, put_in(blueprint.result, result)}
   end

--- a/lib/absinthe/phase/subscription/result.ex
+++ b/lib/absinthe/phase/subscription/result.ex
@@ -6,46 +6,53 @@ defmodule Absinthe.Phase.Subscription.Result do
 
   alias Absinthe.Blueprint
   alias Absinthe.Blueprint.Continuation
+  alias Absinthe.Phase
 
   @spec run(any, Keyword.t()) :: {:ok, Blueprint.t()}
   def run(blueprint, options) do
-    topic = Keyword.get(options, :topic)
+    topic = Keyword.fetch!(options, :topic)
     prime = Keyword.get(options, :prime)
     result = %{"subscribed" => topic}
+
     case prime do
       nil ->
         {:ok, put_in(blueprint.result, result)}
 
-      prime_fun when is_function(prime_fun, 0) ->
-        {:ok, prime_results} = prime_fun.()
-
-        result =
-          if prime_results != [] do
-            continuations =
-              Enum.map(prime_results, fn cr ->
-                %Continuation{
-                  phase_input: blueprint,
-                  pipeline: [
-                    {Absinthe.Phase.Subscription.Prime, [prime_result: cr]},
-                    {Absinthe.Phase.Document.Execution.Resolution, options},
-                    Absinthe.Phase.Document.Result
-                  ]
-                }
-              end)
-
-            Map.put(result, :continuation, continuations)
-          else
-            result
-          end
-
-        {:ok, put_in(blueprint.result, result)}
+      prime_fun when is_function(prime_fun, 1) ->
+        do_prime(prime_fun, result, blueprint, options)
 
       val ->
         raise """
-        Invalid prime function. Must be a function of arity 0.
+        Invalid prime function. Must be a function of arity 1.
 
         #{inspect(val)}
         """
     end
+  end
+
+  def do_prime(prime_fun, base_result, blueprint, options) do
+    {:ok, prime_results} = prime_fun.(blueprint.execution)
+
+    result =
+      if prime_results != [] do
+        continuations =
+          Enum.map(prime_results, fn cr ->
+            %Continuation{
+              phase_input: blueprint,
+              pipeline: [
+                {Phase.Subscription.Prime, [prime_result: cr]},
+                {Phase.Document.Execution.Resolution, options},
+                Phase.Subscription.GetOrdinal,
+                Phase.Document.Result
+              ]
+            }
+          end)
+
+        Map.put(base_result, :continuation, continuations)
+      else
+        base_result
+      end
+
+    {:ok, put_in(blueprint.result, result)}
   end
 end

--- a/lib/absinthe/phase/subscription/subscribe_self.ex
+++ b/lib/absinthe/phase/subscription/subscribe_self.ex
@@ -22,7 +22,7 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
     %{selections: [field]} = op
 
     with {:ok, config} <- get_config(field, context, blueprint) do
-      field_keys = get_field_keys(field, config)
+      {field_keys, prime} = get_field_keys(field, config)
       subscription_id = get_subscription_id(config, blueprint, options)
 
       for field_key <- field_keys,
@@ -30,7 +30,7 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
 
       {:replace, blueprint,
        [
-         {Phase.Subscription.Result, topic: subscription_id},
+         {Phase.Subscription.Result, topic: subscription_id, prime: prime},
          {Phase.Telemetry, Keyword.put(options, :event, [:execute, :operation, :stop])}
        ]}
     else
@@ -96,8 +96,9 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
   defp get_field_keys(%{schema_node: schema_node} = _field, config) do
     name = schema_node.identifier
 
-    find_field_keys!(config)
-    |> Enum.map(fn key -> {name, key} end)
+    {keys, prime} = find_field_keys!(config)
+    field_keys = Enum.map(keys, fn key -> {name, key} end)
+    {field_keys, prime}
   end
 
   defp ensure_pubsub!(context) do
@@ -132,8 +133,12 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
         """
 
       val ->
-        List.wrap(val)
-        |> Enum.map(&to_string/1)
+        topics = List.wrap(val)
+                 |> Enum.map(&to_string/1)
+
+        prime = config[:prime] || nil
+
+        {topics, prime}
     end
   end
 

--- a/lib/absinthe/phase/subscription/subscribe_self.ex
+++ b/lib/absinthe/phase/subscription/subscribe_self.ex
@@ -22,7 +22,7 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
     %{selections: [field]} = op
 
     with {:ok, config} <- get_config(field, context, blueprint) do
-      {field_keys, prime} = get_field_keys(field, config)
+      field_keys = get_field_keys(field, config)
       subscription_id = get_subscription_id(config, blueprint, options)
 
       for field_key <- field_keys,
@@ -30,7 +30,7 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
 
       {:replace, blueprint,
        [
-         {Phase.Subscription.Result, topic: subscription_id, prime: prime},
+         {Phase.Subscription.Result, topic: subscription_id, prime: config[:prime]},
          {Phase.Telemetry, Keyword.put(options, :event, [:execute, :operation, :stop])}
        ]}
     else
@@ -45,11 +45,11 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
     end
   end
 
-  defp get_config(
-         %{schema_node: schema_node, argument_data: argument_data} = field,
-         context,
-         blueprint
-       ) do
+  def get_config(
+        %{schema_node: schema_node, argument_data: argument_data} = field,
+        context,
+        blueprint
+      ) do
     name = schema_node.identifier
 
     config =
@@ -96,9 +96,8 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
   defp get_field_keys(%{schema_node: schema_node} = _field, config) do
     name = schema_node.identifier
 
-    {keys, prime} = find_field_keys!(config)
-    field_keys = Enum.map(keys, fn key -> {name, key} end)
-    {field_keys, prime}
+    find_field_keys!(config)
+    |> Enum.map(fn key -> {name, key} end)
   end
 
   defp ensure_pubsub!(context) do
@@ -133,12 +132,8 @@ defmodule Absinthe.Phase.Subscription.SubscribeSelf do
         """
 
       val ->
-        topics = List.wrap(val)
-                 |> Enum.map(&to_string/1)
-
-        prime = config[:prime] || nil
-
-        {topics, prime}
+        List.wrap(val)
+        |> Enum.map(&to_string/1)
     end
   end
 

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -37,11 +37,14 @@ defmodule Absinthe.Pipeline do
     case result do
       {:ok, blueprint, phases} when rest == [] ->
         {:ok, blueprint, phases}
+
       {:ok, blueprint, phases} ->
         bp_result = Map.put(blueprint.result, :continuation, rest)
         blueprint = Map.put(blueprint, :result, bp_result)
         {:ok, blueprint, phases}
-      error -> error
+
+      error ->
+        error
     end
   end
 
@@ -132,6 +135,7 @@ defmodule Absinthe.Pipeline do
       # Execution
       {Phase.Subscription.SubscribeSelf, options},
       {Phase.Document.Execution.Resolution, options},
+      Phase.Subscription.GetOrdinal,
       # Format Result
       Phase.Document.Result,
       {Phase.Telemetry, Keyword.put(options, :event, [:execute, :operation, :stop])}

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -19,8 +19,6 @@ defmodule Absinthe.Pipeline do
 
   @type run_result_t :: {:ok, data_t, [Phase.t()]} | {:error, String.t(), [Phase.t()]}
 
-  @type continue_result_t :: run_result_t | :no_more_results
-
   @type phase_config_t :: Phase.t() | {Phase.t(), Keyword.t()}
 
   @type t :: [phase_config_t | [phase_config_t]]
@@ -32,7 +30,7 @@ defmodule Absinthe.Pipeline do
     |> run_phase(input)
   end
 
-  @spec continue([Continuation.t()]) :: continue_result_t
+  @spec continue([Continuation.t()]) :: run_result_t
   def continue([continuation | rest]) do
     result = run_phase(continuation.pipeline, continuation.phase_input)
 
@@ -43,7 +41,7 @@ defmodule Absinthe.Pipeline do
       {:ok, blueprint, phases} ->
         bp_result = Map.put(blueprint.result, :continuation, rest)
         blueprint = Map.put(blueprint, :result, bp_result)
-        {:more, blueprint, phases}
+        {:ok, blueprint, phases}
 
       error ->
         error

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -39,7 +39,7 @@ defmodule Absinthe.Pipeline do
         {:ok, blueprint, phases}
 
       {:ok, blueprint, phases} ->
-        bp_result = Map.put(blueprint.result, :continuation, rest)
+        bp_result = Map.put(blueprint.result, :continuations, rest)
         blueprint = Map.put(blueprint, :result, bp_result)
         {:ok, blueprint, phases}
 

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -12,19 +12,37 @@ defmodule Absinthe.Pipeline do
   * See `Absinthe.Schema` on adjusting the schema pipeline for schema manipulation.
   """
 
+  alias Absinthe.Blueprint.Continuation
   alias Absinthe.Phase
 
   @type data_t :: any
+
+  @type run_result_t :: {:ok, data_t, [Phase.t()]} | {:error, String.t(), [Phase.t()]}
 
   @type phase_config_t :: Phase.t() | {Phase.t(), Keyword.t()}
 
   @type t :: [phase_config_t | [phase_config_t]]
 
-  @spec run(data_t, t) :: {:ok, data_t, [Phase.t()]} | {:error, String.t(), [Phase.t()]}
+  @spec run(data_t, t) :: run_result_t
   def run(input, pipeline) do
     pipeline
     |> List.flatten()
     |> run_phase(input)
+  end
+
+  @spec continue([Continuation.t()]) :: run_result_t
+  def continue([continuation | rest]) do
+    result = run_phase(continuation.pipeline, continuation.phase_input)
+
+    case result do
+      {:ok, blueprint, phases} when rest == [] ->
+        {:ok, blueprint, phases}
+      {:ok, blueprint, phases} ->
+        bp_result = Map.put(blueprint.result, :continuation, rest)
+        blueprint = Map.put(blueprint, :result, bp_result)
+        {:ok, blueprint, phases}
+      error -> error
+    end
   end
 
   @defaults [
@@ -388,8 +406,8 @@ defmodule Absinthe.Pipeline do
     end)
   end
 
-  @spec run_phase(t, data_t, [Phase.t()]) ::
-          {:ok, data_t, [Phase.t()]} | {:error, String.t(), [Phase.t()]}
+  @spec run_phase(t, data_t, [Phase.t()]) :: run_result_t
+
   def run_phase(pipeline, input, done \\ [])
 
   def run_phase([], input, done) do

--- a/lib/absinthe/pipeline.ex
+++ b/lib/absinthe/pipeline.ex
@@ -19,6 +19,8 @@ defmodule Absinthe.Pipeline do
 
   @type run_result_t :: {:ok, data_t, [Phase.t()]} | {:error, String.t(), [Phase.t()]}
 
+  @type continue_result_t :: run_result_t | :no_more_results
+
   @type phase_config_t :: Phase.t() | {Phase.t(), Keyword.t()}
 
   @type t :: [phase_config_t | [phase_config_t]]
@@ -30,7 +32,7 @@ defmodule Absinthe.Pipeline do
     |> run_phase(input)
   end
 
-  @spec continue([Continuation.t()]) :: run_result_t
+  @spec continue([Continuation.t()]) :: continue_result_t
   def continue([continuation | rest]) do
     result = run_phase(continuation.pipeline, continuation.phase_input)
 
@@ -41,7 +43,7 @@ defmodule Absinthe.Pipeline do
       {:ok, blueprint, phases} ->
         bp_result = Map.put(blueprint.result, :continuation, rest)
         blueprint = Map.put(blueprint, :result, bp_result)
-        {:ok, blueprint, phases}
+        {:more, blueprint, phases}
 
       error ->
         error

--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -47,6 +47,8 @@ defmodule Absinthe.Subscription do
 
   @type subscription_field_spec :: {atom, term | (term -> term)}
 
+  @type prime_fun :: (-> {:ok, [map()]})
+
   @doc """
   Publish a mutation
 

--- a/lib/absinthe/subscription.ex
+++ b/lib/absinthe/subscription.ex
@@ -47,7 +47,7 @@ defmodule Absinthe.Subscription do
 
   @type subscription_field_spec :: {atom, term | (term -> term)}
 
-  @type prime_fun :: (-> {:ok, [map()]})
+  @type prime_fun :: (Absinthe.Resolution.t() -> {:ok, [map()]})
 
   @doc """
   Publish a mutation

--- a/lib/absinthe/subscription/local.ex
+++ b/lib/absinthe/subscription/local.ex
@@ -46,7 +46,10 @@ defmodule Absinthe.Subscription.Local do
           |> Pipeline.without(Phase.Subscription.SubscribeSelf)
           |> Pipeline.insert_before(
             Phase.Document.Execution.Resolution,
-            {Phase.Document.OverrideRoot, root_value: mutation_result}
+            [
+              {Phase.Document.OverrideRoot, root_value: mutation_result},
+              Phase.Subscription.GetOrdinal
+            ]
           )
           |> Pipeline.upto(Phase.Document.Execution.Resolution)
 

--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -663,7 +663,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
     client_id = "abc"
     prime_data = ["name1", "name2"]
 
-    assert {:more, %{"subscribed" => _topic, continuation: continuation}} =
+    assert {:more, %{"subscribed" => _topic, continuations: continuations}} =
              run_subscription(
                @query,
                Schema,
@@ -677,17 +677,17 @@ defmodule Absinthe.Execution.SubscriptionTest do
     assert {:more,
             %{
               data: %{"prime" => %{"id" => "test_prime_id", "name" => "name1"}},
-              continuation: continuation
-            }} = Absinthe.continue(continuation)
+              continuations: continuations
+            }} = Absinthe.continue(continuations)
 
     assert {:ok, %{data: %{"prime" => %{"id" => "test_prime_id", "name" => "name2"}}}} =
-             Absinthe.continue(continuation)
+             Absinthe.continue(continuations)
   end
 
   test "continuation with no extra data" do
     client_id = "abc"
 
-    assert {:more, %{"subscribed" => _topic, continuation: continuation}} =
+    assert {:more, %{"subscribed" => _topic, continuations: continuations}} =
              run_subscription(
                @query,
                Schema,
@@ -698,7 +698,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
                context: %{prime_id: "test_prime_id"}
              )
 
-    assert :no_more_results == Absinthe.continue(continuation)
+    assert :no_more_results == Absinthe.continue(continuations)
   end
 
   @query """
@@ -741,7 +741,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
   test "subscription with both priming and ordinals" do
     client_id = "abc"
 
-    assert {:more, %{"subscribed" => _topic, continuation: continuation}} =
+    assert {:more, %{"subscribed" => _topic, continuations: continuations}} =
              run_subscription(
                @query,
                Schema,
@@ -754,11 +754,11 @@ defmodule Absinthe.Execution.SubscriptionTest do
             %{
               data: %{"primeOrdinal" => %{"name" => "first_user"}},
               ordinal: 1,
-              continuation: continuation
-            }} = Absinthe.continue(continuation)
+              continuations: continuations
+            }} = Absinthe.continue(continuations)
 
     assert {:ok, %{data: %{"primeOrdinal" => %{"name" => "second_user"}}, ordinal: 2}} =
-             Absinthe.continue(continuation)
+             Absinthe.continue(continuations)
   end
 
   defp run_subscription(query, schema, opts \\ []) do

--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -684,6 +684,23 @@ defmodule Absinthe.Execution.SubscriptionTest do
              Absinthe.continue(continuation)
   end
 
+  test "continuation with no extra data" do
+    client_id = "abc"
+
+    assert {:more, %{"subscribed" => _topic, continuation: continuation}} =
+             run_subscription(
+               @query,
+               Schema,
+               variables: %{
+                 "primeData" => [],
+                 "clientId" => client_id
+               },
+               context: %{prime_id: "test_prime_id"}
+             )
+
+    assert :no_more_results == Absinthe.continue(continuation)
+  end
+
   @query """
   subscription ($clientId: ID!) {
     ordinal(clientId: $clientId) {

--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -215,7 +215,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
 
     assert %{
              event: "subscription:data",
-             result: %{data: %{"thing" => "foo"}, ordinal: nil},
+             result: %{data: %{"thing" => "foo"}},
              topic: topic
            } == msg
   end
@@ -259,7 +259,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
 
     msg = %{
       event: "subscription:data",
-      result: %{data: %{"multipleTopics" => "foo"}, ordinal: nil},
+      result: %{data: %{"multipleTopics" => "foo"}},
       topic: topic
     }
 
@@ -361,7 +361,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
 
     assert %{
              event: "subscription:data",
-             result: %{data: %{"user" => %{"id" => "1", "name" => "foo"}}, ordinal: nil},
+             result: %{data: %{"user" => %{"id" => "1", "name" => "foo"}}},
              topic: topic
            } == msg
   end
@@ -409,7 +409,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
 
     assert %{
              event: "subscription:data",
-             result: %{data: %{"thing" => "foo"}, ordinal: nil},
+             result: %{data: %{"thing" => "foo"}},
              topic: topic
            } == msg
   end
@@ -428,7 +428,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
 
         assert %{
                  event: "subscription:data",
-                 result: %{data: %{"thing" => "foo"}, ordinal: nil},
+                 result: %{data: %{"thing" => "foo"}},
                  topic: topic
                } == msg
       end)
@@ -640,7 +640,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
 
     assert %{
              event: "subscription:data",
-             result: %{data: %{"thing" => "foo"}, ordinal: nil},
+             result: %{data: %{"thing" => "foo"}},
              topic: topic
            } == msg
 

--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -47,6 +47,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
     object :user do
       field :id, :id
       field :name, :string
+      field :version, :integer
 
       field :group, :group do
         resolve fn user, _, %{context: %{test_pid: pid}} ->
@@ -113,7 +114,6 @@ defmodule Absinthe.Execution.SubscriptionTest do
         end
       end
 
-
       field :other_user, :user do
         arg :id, :id
 
@@ -141,9 +141,36 @@ defmodule Absinthe.Execution.SubscriptionTest do
           {
             :ok,
             topic: args.client_id,
-            prime: fn ->
-              {:ok, Enum.map(args.prime_data, &(%{id: "some_id", name: &1}))}
+            prime: fn %{context: %{prime_id: prime_id}} ->
+              {:ok, Enum.map(args.prime_data, &%{id: prime_id, name: &1})}
             end
+          }
+        end
+      end
+
+      field :ordinal, :user do
+        arg :client_id, non_null(:id)
+
+        config fn args, _ ->
+          {
+            :ok,
+            topic: args.client_id, ordinal: fn %{version: version} -> version end
+          }
+        end
+      end
+
+      field :prime_ordinal, :user do
+        arg :client_id, non_null(:id)
+        arg :prime_data, list_of(:string)
+
+        config fn args, _ ->
+          {
+            :ok,
+            topic: args.client_id,
+            prime: fn _ ->
+              {:ok, [%{name: "first_user", version: 1}, %{name: "second_user", version: 2}]}
+            end,
+            ordinal: fn %{version: version} -> version end
           }
         end
       end
@@ -188,7 +215,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
 
     assert %{
              event: "subscription:data",
-             result: %{data: %{"thing" => "foo"}},
+             result: %{data: %{"thing" => "foo"}, ordinal: nil},
              topic: topic
            } == msg
   end
@@ -232,7 +259,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
 
     msg = %{
       event: "subscription:data",
-      result: %{data: %{"multipleTopics" => "foo"}},
+      result: %{data: %{"multipleTopics" => "foo"}, ordinal: nil},
       topic: topic
     }
 
@@ -334,7 +361,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
 
     assert %{
              event: "subscription:data",
-             result: %{data: %{"user" => %{"id" => "1", "name" => "foo"}}},
+             result: %{data: %{"user" => %{"id" => "1", "name" => "foo"}}, ordinal: nil},
              topic: topic
            } == msg
   end
@@ -382,7 +409,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
 
     assert %{
              event: "subscription:data",
-             result: %{data: %{"thing" => "foo"}},
+             result: %{data: %{"thing" => "foo"}, ordinal: nil},
              topic: topic
            } == msg
   end
@@ -401,7 +428,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
 
         assert %{
                  event: "subscription:data",
-                 result: %{data: %{"thing" => "foo"}},
+                 result: %{data: %{"thing" => "foo"}, ordinal: nil},
                  topic: topic
                } == msg
       end)
@@ -613,7 +640,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
 
     assert %{
              event: "subscription:data",
-             result: %{data: %{"thing" => "foo"}},
+             result: %{data: %{"thing" => "foo"}, ordinal: nil},
              topic: topic
            } == msg
 
@@ -627,12 +654,13 @@ defmodule Absinthe.Execution.SubscriptionTest do
   @query """
   subscription ($clientId: ID!, $primeData: [String]) {
     prime(clientId: $clientId, primeData: $primeData) {
+      id
       name
     }
   }
   """
   test "subscription with priming" do
-    client_id = "xyz"
+    client_id = "abc"
     prime_data = ["name1", "name2"]
 
     assert {:more, %{"subscribed" => _topic, continuation: continuation}} =
@@ -642,16 +670,78 @@ defmodule Absinthe.Execution.SubscriptionTest do
                variables: %{
                  "primeData" => prime_data,
                  "clientId" => client_id
+               },
+               context: %{prime_id: "test_prime_id"}
+             )
+
+    assert {:more,
+            %{
+              data: %{"prime" => %{"id" => "test_prime_id", "name" => "name1"}},
+              continuation: continuation
+            }} = Absinthe.continue(continuation)
+
+    assert {:ok, %{data: %{"prime" => %{"id" => "test_prime_id", "name" => "name2"}}}} =
+             Absinthe.continue(continuation)
+  end
+
+  @query """
+  subscription ($clientId: ID!) {
+    ordinal(clientId: $clientId) {
+      name
+    }
+  }
+  """
+  test "subscription with ordinals" do
+    client_id = "abc"
+
+    assert {:ok, %{"subscribed" => _topic}} =
+             run_subscription(
+               @query,
+               Schema,
+               variables: %{"clientId" => client_id},
+               context: %{pubsub: PubSub}
+             )
+
+    userv1 = %{id: "1", name: "Alicia", group: %{name: "Elixir Users"}, version: 1}
+    userv2 = %{id: "1", name: "Alicia", group: %{name: "Elixir Users"}, version: 2}
+
+    Absinthe.Subscription.publish(PubSub, userv1, ordinal: client_id)
+    Absinthe.Subscription.publish(PubSub, userv2, ordinal: client_id)
+
+    assert_receive({:broadcast, msg})
+    assert msg.result.ordinal == 1
+    assert_receive({:broadcast, msg})
+    assert msg.result.ordinal == 2
+  end
+
+  @query """
+  subscription ($clientId: ID!) {
+    primeOrdinal(clientId: $clientId) {
+      name
+    }
+  }
+  """
+  test "subscription with both priming and ordinals" do
+    client_id = "abc"
+
+    assert {:more, %{"subscribed" => _topic, continuation: continuation}} =
+             run_subscription(
+               @query,
+               Schema,
+               variables: %{
+                 "clientId" => client_id
                }
              )
 
-    assert {:more, %{
-      data: %{"prime" => %{"name" => "name1"}},
-      continuation: continuation}}
-      = Absinthe.continue(continuation)
+    assert {:more,
+            %{
+              data: %{"primeOrdinal" => %{"name" => "first_user"}},
+              ordinal: 1,
+              continuation: continuation
+            }} = Absinthe.continue(continuation)
 
-    assert {:ok, %{data: %{"prime" => %{"name" => "name2"}}}}
-    = Absinthe.continue(continuation)
+    assert {:ok, %{data: %{"primeOrdinal" => %{"name" => "second_user"}}, ordinal: 2}} =
+             Absinthe.continue(continuation)
   end
 
   defp run_subscription(query, schema, opts \\ []) do

--- a/test/absinthe/execution/subscription_test.exs
+++ b/test/absinthe/execution/subscription_test.exs
@@ -113,6 +113,7 @@ defmodule Absinthe.Execution.SubscriptionTest do
         end
       end
 
+
       field :other_user, :user do
         arg :id, :id
 
@@ -129,6 +130,21 @@ defmodule Absinthe.Execution.SubscriptionTest do
         config fn _, %{document: %Absinthe.Blueprint{} = document} ->
           %{type: :subscription, name: op_name} = Absinthe.Blueprint.current_operation(document)
           {:ok, topic: "*", context_id: "*", document_id: op_name}
+        end
+      end
+
+      field :prime, :user do
+        arg :client_id, non_null(:id)
+        arg :prime_data, list_of(:string)
+
+        config fn args, _ ->
+          {
+            :ok,
+            topic: args.client_id,
+            prime: fn ->
+              {:ok, Enum.map(args.prime_data, &(%{id: "some_id", name: &1}))}
+            end
+          }
         end
       end
     end
@@ -608,11 +624,41 @@ defmodule Absinthe.Execution.SubscriptionTest do
     :telemetry.detach(context.test)
   end
 
+  @query """
+  subscription ($clientId: ID!, $primeData: [String]) {
+    prime(clientId: $clientId, primeData: $primeData) {
+      name
+    }
+  }
+  """
+  test "subscription with priming" do
+    client_id = "xyz"
+    prime_data = ["name1", "name2"]
+
+    assert {:more, %{"subscribed" => _topic, continuation: continuation}} =
+             run_subscription(
+               @query,
+               Schema,
+               variables: %{
+                 "primeData" => prime_data,
+                 "clientId" => client_id
+               }
+             )
+
+    assert {:more, %{
+      data: %{"prime" => %{"name" => "name1"}},
+      continuation: continuation}}
+      = Absinthe.continue(continuation)
+
+    assert {:ok, %{data: %{"prime" => %{"name" => "name2"}}}}
+    = Absinthe.continue(continuation)
+  end
+
   defp run_subscription(query, schema, opts \\ []) do
     opts = Keyword.update(opts, :context, %{pubsub: PubSub}, &Map.put(&1, :pubsub, PubSub))
 
-    case run(query, schema, opts) do
-      {:ok, %{"subscribed" => topic}} = val ->
+    case Absinthe.run(query, schema, opts) do
+      {response, %{"subscribed" => topic}} = val when response == :ok or response == :more ->
         PubSub.subscribe(topic)
         val
 


### PR DESCRIPTION
Hey, I checked out your branch!

With the two changes that I made it works good for me - though the second change is an issue that probably creates more problems then it solves.

The first fix is just a trivial fix that handles an oversight: In absinthe you can have a GraphQL query that returns a single element instead of a list, the way the code worked before it was assuming that its a list, just added the case and that fixed the problem.

The second thing is that I commented out the line in get_ordinal because it causes problems for me.
And since I do not use the ordinal feature I can not properly test it for you so I will refrain from changing anything here beyond disabling the feature.
The reason why this causes a problem is that I (and I assume many others) have side effects in their subscription config function.
And this causes it to be called multiple times. This breaks my entire app and will probably have to be
done differently unless you want the library to have breaking changes for many users. Probably it can be solved by passing the ordinal callback to the options in the same way you handle it for prime, though it seems to me ordinal is handled in a bit more complex way then prime, and is dispatched in ways that I would need some time to understand, which is why I refrained from changing the logic and just commented it out to make the branch work for my project. 

Other then that it is great and does what its supposed to do, if other issues arise I will report. 

Best